### PR TITLE
Link ethashcl also if it's found in the path

### DIFF
--- a/cmake/UseEth.cmake
+++ b/cmake/UseEth.cmake
@@ -17,7 +17,7 @@ function(eth_apply TARGET REQUIRED SUBMODULE)
 	endif()
 
 	if (${SUBMODULE} STREQUAL "ethash-cl")
-		if (ETHASHCL)
+		if (ETHASHCL OR Eth_ETHASH-CL_LIBRARIES)
 			if (OpenCL_FOUND)
 				eth_use(${TARGET} ${REQUIRED} Eth::ethash)
 				target_include_directories(${TARGET} SYSTEM PUBLIC ${OpenCL_INCLUDE_DIRS})


### PR DESCRIPTION
In windows when building with split repositories webthree seems to
require ethashcl if first libethereum was built with libethash-cl
on (which is the default)

The way webthree's cmake files are at the moment it will try to link to
ethashcl but because nowhere is `ETHASCL` set it will not do it,
resulting in undefined link symbols.

With this commit I believe we also allow linking not only if ETHASHCL has
been set but also if  we have already compiled ETHASH-CL and cmake found it.
