### PR TITLE
Modified OpenCL header path which is used for mac.

### DIFF
--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -44,7 +44,7 @@ function(_FIND_OPENCL_VERSION)
     if(APPLE)
       CHECK_SYMBOL_EXISTS(
         CL_VERSION_${VERSION}
-        "${OpenCL_INCLUDE_DIR}/OpenCL/cl.h"
+        "OpenCL/cl.h"
         OPENCL_VERSION_${VERSION})
     else()
       CHECK_SYMBOL_EXISTS(


### PR DESCRIPTION
In MacOSX, OpenCL header is in following path.
`${OpenCL_INCLUDE_DIR}/Headers/cl.h`
