### PR TITLE
Use LLVM 3.7.0 on Windows.

### DIFF
--- a/extdep/getstuff.bat
+++ b/extdep/getstuff.bat
@@ -1,5 +1,5 @@
 REM get stuff!
-if not exist download mkdir download 
+if not exist download mkdir download
 if not exist install mkdir install
 if not exist install\windows mkdir install\windows
 
@@ -11,7 +11,7 @@ call :download curl 7.4.2
 call :download jsoncpp 1.6.2
 call :download json-rpc-cpp 0.5.0
 call :download leveldb 1.2
-call :download llvm 3.7svn
+call :download llvm 3.7.0
 call :download microhttpd 0.9.2
 call :download OpenCL_ICD 1
 call :download qt 5.4.1
@@ -39,4 +39,3 @@ cmake -E copy_directory %eth_name%-%eth_version% ..\install\windows
 cd ..
 
 goto :EOF
-


### PR DESCRIPTION
After 2 days of works... Windows binaries are able to be built with LLVM 3.7.0.

I have no idea how to support both debug and release builds.
