### PR TITLE
Build secp256k1 library on Windows.

### DIFF
--- a/cmake/UseUtils.cmake
+++ b/cmake/UseUtils.cmake
@@ -10,11 +10,7 @@ function(eth_apply TARGET REQUIRED SUBMODULE)
 	target_include_directories(${TARGET} SYSTEM BEFORE PUBLIC ${Utils_INCLUDE_DIRS})
 
 	if (${SUBMODULE} STREQUAL "secp256k1")
-		if (NOT EMSCRIPTEN)
-			eth_use(${TARGET} ${REQUIRED} Gmp)
-		endif()
 		target_link_libraries(${TARGET} ${Utils_SECP256K1_LIBRARIES})
-		target_compile_definitions(${TARGET} PUBLIC ETH_HAVE_SECP256K1)
 	endif()
 
 	if (${SUBMODULE} STREQUAL "scrypt")

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -18,6 +18,6 @@ include(EthDependencies)
 
 add_subdirectory(libscrypt)
 
-if ((NOT EMSCRIPTEN) AND (NOT DEFINED MSVC))
+if (NOT EMSCRIPTEN)
 	add_subdirectory(secp256k1)
 endif()

--- a/utils/secp256k1/CMakeLists.txt
+++ b/utils/secp256k1/CMakeLists.txt
@@ -2,7 +2,7 @@
 file(GLOB HEADERS "*.h")
 
 add_library(secp256k1 secp256k1.c include/secp256k1.h ${HEADERS})
-target_compile_definitions(secp256k1 PRIVATE -DHAVE_CONFIG_H)
+target_compile_definitions(secp256k1 INTERFACE ETH_HAVE_SECP256K1 PRIVATE HAVE_CONFIG_H)
 
 if (NOT MSVC)
 	eth_use(secp256k1 REQUIRED Gmp)

--- a/utils/secp256k1/CMakeLists.txt
+++ b/utils/secp256k1/CMakeLists.txt
@@ -1,10 +1,10 @@
-set(EXECUTABLE secp256k1)
-file(GLOB HEADERS "*.h") 
 
-add_library(${EXECUTABLE} ${EXECUTABLE}.c)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_CONFIG_H -g -O2 -W -std=c89 -pedantic -Wall -Wextra -Wcast-align -Wnested-externs -Wshadow -Wstrict-prototypes -Wno-unused-function -Wno-long-long -Wno-overlength-strings")
+file(GLOB HEADERS "*.h")
 
-eth_use(${EXECUTABLE} REQUIRED Gmp)
+add_library(secp256k1 secp256k1.c include/secp256k1.h ${HEADERS})
+target_compile_definitions(secp256k1 PRIVATE -DHAVE_CONFIG_H)
 
-install( TARGETS ${EXECUTABLE} RUNTIME DESTINATION bin ARCHIVE DESTINATION lib LIBRARY DESTINATION lib )
-install( FILES ${HEADERS} DESTINATION include/${EXECUTABLE} )
+if (NOT MSVC)
+	eth_use(secp256k1 REQUIRED Gmp)
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -W -std=c89 -pedantic -Wall -Wextra -Wcast-align -Wnested-externs -Wshadow -Wstrict-prototypes -Wno-unused-function -Wno-long-long -Wno-overlength-strings")
+endif()

--- a/utils/secp256k1/libsecp256k1-config.h
+++ b/utils/secp256k1/libsecp256k1-config.h
@@ -12,19 +12,15 @@
 /* #undef ENABLE_OPENSSL_TESTS */
 
 /* Define this symbol if __builtin_expect is available */
+#if !defined(_MSC_VER)
 #define HAVE_BUILTIN_EXPECT 1
+#endif
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1
 
 /* Define to 1 if you have the <inttypes.h> header file. */
 #define HAVE_INTTYPES_H 1
-
-/* Define this symbol if libcrypto is installed */
-/* #undef HAVE_LIBCRYPTO */
-
-/* Define this symbol if libgmp is installed */
-#define HAVE_LIBGMP 1
 
 /* Define to 1 if you have the <memory.h> header file. */
 #define HAVE_MEMORY_H 1
@@ -51,7 +47,7 @@
 #define HAVE_UNISTD_H 1
 
 /* Define to 1 if the system has the type `__int128'. */
-#if defined(__x86_64__) || defined(_M_X64)
+#if !defined(_MSC_VER) && (defined(__x86_64__) || defined(_M_X64))
 #define HAVE___INT128 1
 #endif
 
@@ -88,35 +84,41 @@
 /* Define this symbol to use endomorphism optimization */
 /* #undef USE_ENDOMORPHISM */
 
-#if defined(__x86_64__) || defined(_M_X64)
+/* Select implementation for num */
+#if defined(_MSC_VER)
+#define USE_NUM_NONE 1
+#else
+#define USE_NUM_GMP 1
+#endif
+
+/* Select implementation for field */
+#if HAVE___INT128
 #define USE_FIELD_5X52 1
-#elif defined(__i386) || defined(_M_IX86) || defined(__arm__) || defined(__M_ARM)
+#else
 #define USE_FIELD_10X26 1
 #endif
 
-/* Define this symbol to use the native field inverse implementation */
-/* #undef USE_FIELD_INV_BUILTIN */
-
-/* Define this symbol to use the num-based field inverse implementation */
+/* Select field inverse implementation */
+#if USE_NUM_GMP
 #define USE_FIELD_INV_NUM 1
+#else
+#define USE_FIELD_INV_BUILTIN 1
+#endif
 
-/* Define this symbol to use the gmp implementation for num */
-#define USE_NUM_GMP 1
-
-/* Define this symbol to use no num implementation */
-/* #undef USE_NUM_NONE */
-
-#if defined(__x86_64__) || defined(_M_X64)
+/* Select implementation for scalar */
+#if HAVE___INT128
 #define USE_SCALAR_4X64 1
-#elif defined(__i386) || defined(_M_IX86) || defined(__arm__) || defined(__M_ARM)
+#else
 #define USE_SCALAR_8X32 1
 #endif
 
 /* Define this symbol to use the native scalar inverse implementation */
-/* #undef USE_SCALAR_INV_BUILTIN */
-
-/* Define this symbol to use the num-based scalar inverse implementation */
+/* Select scalar inverse implementation */
+#if USE_NUM_GMP
 #define USE_SCALAR_INV_NUM 1
+#else
+#define USE_SCALAR_INV_BUILTIN 1
+#endif
 
 /* Version number of package */
 #define VERSION "0.1"


### PR DESCRIPTION
GMP is not required for secp256k1, but it makes the library a bit faster. However they are working on internal inverse implementation to drop GMP dependency entirely. 
