### PR TITLE
Fix URL of brew bottle

### DIFF
--- a/homebrew/cpp-ethereum.rb.in
+++ b/homebrew/cpp-ethereum.rb.in
@@ -9,14 +9,14 @@ class CppEthereum < Formula
 
   bottle do
     revision CFG_NUMBER
-    root_url 'http://52.28.164.97/job/ethbinaries-build/label=macosx_slave/CFG_NUMBER/artifact/webthree-umbrella/build'
+    root_url 'https://build.ethdev.com/cpp-binaries-data/brew_receipts'
     sha1 'CFG_SIGNATURE' => :yosemite
   end
 
   devel do
     bottle do
       revision CFG_NUMBER
-      root_url 'http://52.28.164.97/job/ethbinaries-build/label=macosx_slave/CFG_NUMBER/artifact/webthree-umbrella/build'
+      root_url 'https://build.ethdev.com/cpp-binaries-data/brew_receipts'
       sha1 'CFG_SIGNATURE' => :yosemite
     end
 


### PR DESCRIPTION
Should not point to the jenkins instance, but instead at the deployed
artifact location
