### PR TITLE
Remove the version from the windows installer

### DIFF
--- a/cmake/EthExecutableHelper.cmake
+++ b/cmake/EthExecutableHelper.cmake
@@ -197,6 +197,7 @@ macro(eth_nsis)
 			set(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "${CPACK_PACKAGE_NAME} ${CPACK_PACKAGE_VERSION}")
 		endif()
 
+		set(CPACK_PACKAGE_FILE_NAME "Ethereum")
 		set(CPACK_NSIS_DISPLAY_NAME "Ethereum")
 		set(CPACK_NSIS_HELP_LINK "https://github.com/ethereum/cpp-ethereum")
 		set(CPACK_NSIS_URL_INFO_ABOUT "https://github.com/ethereum/cpp-ethereum")


### PR DESCRIPTION
As requested, this should hopefully remove the version from the jenkins
installer. It would still need to be tested in Jenkins.

Jenkins will be making directories with each version and putting the
installer/binaries inside.
