### PR TITLE
Cmake OpenCL discovery should now work properly

### DIFF
--- a/cmake/UseOpenCL.cmake
+++ b/cmake/UseOpenCL.cmake
@@ -1,10 +1,15 @@
-function(eth_apply TARGET REQUIRED)	
+function(eth_apply TARGET REQUIRED)
 	find_package (OpenCL)
 	eth_show_dependency(OpenCL OpenCL)
 	if (OpenCL_FOUND)
 		target_include_directories(${TARGET} SYSTEM PUBLIC ${OpenCL_INCLUDE_DIRS})
 		target_link_libraries(${TARGET} ${OpenCL_LIBRARIES})
 		eth_copy_dlls(${TARGET} OpenCL_DLLS)
+		# as per this comment: http://cmake.3232098.n2.nabble.com/Scope-of-find-package-inside-a-function-block-tp6821980p6822888.html
+		# It seems that calling find_package() inside a cmake function will only set the found
+		# and libs variables only for the local scope. We need to set it with a cached (global)
+		# scope here in order to be visible outside the eth_use(${TARGET} ${REQUIRED} OpenCL) call
+		set(OpenCL_FOUND 1 CACHE INTERNAL "")
 	elseif (NOT ${REQUIRED} STREQUAL "OPTIONAL")
 		message(FATAL_ERROR "OpenCL library not found")
 	endif()


### PR DESCRIPTION
Using find_package() inside a cmake function will unfortunately set the
`XXX_FOUND` variable only for the local function scope. So for custom
find/use functions we need to make sure that we propagate the FOUND
variable if we rely on it as we do with the `OpenCL_FOUND` one.
