### PR TITLE
Jsonrpc moduls

### DIFF
--- a/cmake/scripts/jsonrpcstub.cmake
+++ b/cmake/scripts/jsonrpcstub.cmake
@@ -51,7 +51,7 @@ else ()
 	# 	sed -e s/include\ \<jsonrpccpp\\/server\.h\>/include\ ${INCLUDE_NAME}/g \
 	#		-e s/public\ jsonrpc::AbstractServer\<${NAME}\>/public\ ServerInterface\<${NAME}\>/g \
 	#		-e s/${NAME}\(jsonrpc::AbstractServerConnector\ \&conn,\ jsonrpc::serverVersion_t\ type\ =\ jsonrpc::JSONRPC_SERVER_V2\)\ :\ jsonrpc::AbstractServer\<${NAME}\>\(conn,\ type\)/${NAME}\(\)/g \
-	string(REGEX REPLACE "include\ <jsonrpccpp\/server\.h>" "include\ \"ModularServer.h\"" SERVER_CONTENT "${SERVER_CONTENT}")
+	string(REGEX REPLACE "include\ <jsonrpccpp/server\.h>" "include\ \"ModularServer.h\"" SERVER_CONTENT "${SERVER_CONTENT}")
 	string(REGEX REPLACE "public\ jsonrpc::AbstractServer<${ETH_SERVER_NAME}>" "public ServerInterface<${ETH_SERVER_NAME}>" SERVER_CONTENT "${SERVER_CONTENT}")
 	string(REGEX REPLACE "${ETH_SERVER_NAME}\\(jsonrpc::AbstractServerConnector\ &conn,\ jsonrpc::serverVersion_t\ type\ =\ jsonrpc::JSONRPC_SERVER_V2\\)\ :\ jsonrpc::AbstractServer<${ETH_SERVER_NAME}>\\(conn, type\\)" "${ETH_SERVER_NAME}()" SERVER_CONTENT "${SERVER_CONTENT}")
 

--- a/cmake/scripts/jsonrpcstub.cmake
+++ b/cmake/scripts/jsonrpcstub.cmake
@@ -44,6 +44,18 @@ else ()
 			--cpp-client=${ETH_CLIENT_NAME} --cpp-client-file=${CLIENT_TMPFILE}
 			OUTPUT_VARIABLE ERR ERROR_QUIET
 	)
+
+	file(READ ${SERVER_TMPFILE} SERVER_CONTENT)
+
+	# The following cmake regexps are equal to this sed command
+	# 	sed -e s/include\ \<jsonrpccpp\\/server\.h\>/include\ ${INCLUDE_NAME}/g \
+	#		-e s/public\ jsonrpc::AbstractServer\<${NAME}\>/public\ ServerInterface\<${NAME}\>/g \
+	#		-e s/${NAME}\(jsonrpc::AbstractServerConnector\ \&conn,\ jsonrpc::serverVersion_t\ type\ =\ jsonrpc::JSONRPC_SERVER_V2\)\ :\ jsonrpc::AbstractServer\<${NAME}\>\(conn,\ type\)/${NAME}\(\)/g \
+	string(REGEX REPLACE "include\ <jsonrpccpp\/server\.h>" "include\ \"ModularServer.h\"" SERVER_CONTENT "${SERVER_CONTENT}")
+	string(REGEX REPLACE "public\ jsonrpc::AbstractServer<${ETH_SERVER_NAME}>" "public ServerInterface<${ETH_SERVER_NAME}>" SERVER_CONTENT "${SERVER_CONTENT}")
+	string(REGEX REPLACE "${ETH_SERVER_NAME}\\(jsonrpc::AbstractServerConnector\ &conn,\ jsonrpc::serverVersion_t\ type\ =\ jsonrpc::JSONRPC_SERVER_V2\\)\ :\ jsonrpc::AbstractServer<${ETH_SERVER_NAME}>\\(conn, type\\)" "${ETH_SERVER_NAME}()" SERVER_CONTENT "${SERVER_CONTENT}")
+
+	file(WRITE ${SERVER_TMPFILE} "${SERVER_CONTENT}")
 endif()
 
 # don't throw fatal error on jsonrpcstub error, someone might have old version of jsonrpcstub,


### PR DESCRIPTION
part of changes required for modularization of jsonrpc.

These additional lines in `jsonrpcstub.cmake` alters generated header file, so the abstract class inherit from `ServerInterface` instead of `AbstractServerConnector`

description:
- https://github.com/ethereum/webthree/pull/59
