### PR TITLE
fix jsonrpcstub.cmake regex

### DIFF
--- a/cmake/scripts/jsonrpcstub.cmake
+++ b/cmake/scripts/jsonrpcstub.cmake
@@ -57,7 +57,7 @@ else ()
 	# 	sed -e s/include\ \<jsonrpccpp\\/server\.h\>/include\ ${INCLUDE_NAME}/g \
 	#		-e s/public\ jsonrpc::AbstractServer\<${NAME}\>/public\ ServerInterface\<${NAME}\>/g \
 	#		-e s/${NAME}\(jsonrpc::AbstractServerConnector\ \&conn,\ jsonrpc::serverVersion_t\ type\ =\ jsonrpc::JSONRPC_SERVER_V2\)\ :\ jsonrpc::AbstractServer\<${NAME}\>\(conn,\ type\)/${NAME}\(\)/g \
-	string(REGEX REPLACE "include\ <jsonrpccpp/server\.h>" "include\ \"ModularServer.h\"" SERVER_CONTENT "${SERVER_CONTENT}")
+	string(REGEX REPLACE "include\ <jsonrpccpp/server.h>" "include\ \"ModularServer.h\"" SERVER_CONTENT "${SERVER_CONTENT}")
 	string(REGEX REPLACE "public\ jsonrpc::AbstractServer<${SERVER_NAME}>" "public ServerInterface<${SERVER_NAME}>" SERVER_CONTENT "${SERVER_CONTENT}")
 	string(REGEX REPLACE "${SERVER_NAME}\\(jsonrpc::AbstractServerConnector\ &conn,\ jsonrpc::serverVersion_t\ type\ =\ jsonrpc::JSONRPC_SERVER_V2\\)\ :\ jsonrpc::AbstractServer<${SERVER_NAME}>\\(conn, type\\)" "${SERVER_NAME}()" SERVER_CONTENT "${SERVER_CONTENT}")
 


### PR DESCRIPTION
I was getting this warning when compiling:

```
cd /home/lefteris/ew/webthree/build/ && make -j4
CMake Warning (dev) at /home/lefteris/ew/webthree-helpers/cmake/scripts/jsonrpcstub.cmake:60 (string):
  Syntax error in cmake code at

    /home/lefteris/ew/webthree-helpers/cmake/scripts/jsonrpcstub.cmake:60

  when parsing string

    include\ <jsonrpccpp/server\.h>

  Invalid escape sequence \.

  Policy CMP0010 is not set: Bad variable reference syntax is an error.  Run
  "cmake --help-policy CMP0010" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at /home/lefteris/ew/webthree-helpers/cmake/scripts/jsonrpcstub.cmake:60 (string):
  Syntax error in cmake code at

    /home/lefteris/ew/webthree-helpers/cmake/scripts/jsonrpcstub.cmake:60

  when parsing string

    include\ <jsonrpccpp/server\.h>

  Invalid escape sequence \.

  Policy CMP0010 is not set: Bad variable reference syntax is an error.  Run
  "cmake --help-policy CMP0010" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

[  0%] Built target webthree_BuildInfo.h
[  0%] Built target db.jsonstub
[  0%] Built target spec.jsonstub
[ 13%] Built target jsengine
[ 26%] Built target whisper
[ 39%] Built target jsconsole
```

DEPENDS:
{"webthree":"fix_linux_build"}
