### PR TITLE
Fix missed framework contents

### DIFF
--- a/cmake/scripts/macdeployfix.sh
+++ b/cmake/scripts/macdeployfix.sh
@@ -53,6 +53,14 @@ for i in "${BROKEN_FRAMEWORKS[@]}"; do
 	otool -L $FRAMEWORK_FILE | grep -o /usr/.*Qt.*framework/\\w* | while read -a libs ; do
 	       	install_name_tool -change ${libs[0]} @loader_path/../../../`basename ${libs[0]}`.framework/`basename ${libs[0]}` $FRAMEWORK_FILE
 	done
+	#Also fix apps included *inside* these frameworks in the same way. Currently, only QtWebEngineProcess.app inside QtWebEngineCore
+	#is affected, but trying to keep this general...
+	for j in $(find $i/ -name "*.app"); do
+		EXEC_NAME=$j/Contents/MacOS/$(basename -s ".app" $j)
+		otool -L $EXEC_NAME | grep -o /usr/local.*dylib | while read -a innerlibs ; do
+			install_name_tool -change ${innerlibs[0]} @loader_path/../Frameworks/`basename ${innerlibs[0]}` $EXEC_NAME
+		done
+	done
 done
 
 declare -a BROKEN_PLUGINS;

--- a/cmake/scripts/macdeployfix.sh
+++ b/cmake/scripts/macdeployfix.sh
@@ -58,8 +58,8 @@ for i in "${BROKEN_FRAMEWORKS[@]}"; do
 	# This is due to a known bug in QT5, and we have to fix up the linked libraries if we're going to have a distributable
 	# result of building. When https://bugreports.qt.io/browse/QTBUG-50155 is fixed, this should be able
 	# to be removed.
-	for j in $(find $i/ -name "*.app"); do
-		EXEC_NAME=$j/Contents/MacOS/$(basename -s ".app" $j)
+	for j in $(find $i/ -name *.app); do
+		EXEC_NAME=$j/Contents/MacOS/$(basename -s .app $j)
 		otool -L $EXEC_NAME | grep -o /usr/local.*dylib | while read -a innerlibs ; do
 			install_name_tool -change ${innerlibs[0]} @loader_path/../Frameworks/`basename ${innerlibs[0]}` $EXEC_NAME
 		done

--- a/cmake/scripts/macdeployfix.sh
+++ b/cmake/scripts/macdeployfix.sh
@@ -53,8 +53,11 @@ for i in "${BROKEN_FRAMEWORKS[@]}"; do
 	otool -L $FRAMEWORK_FILE | grep -o /usr/.*Qt.*framework/\\w* | while read -a libs ; do
 	       	install_name_tool -change ${libs[0]} @loader_path/../../../`basename ${libs[0]}`.framework/`basename ${libs[0]}` $FRAMEWORK_FILE
 	done
-	#Also fix apps included *inside* these frameworks in the same way. Currently, only QtWebEngineProcess.app inside QtWebEngineCore
-	#is affected, but trying to keep this general...
+	# This next loop also fixes apps included *inside* these frameworks in the same way. Currently, only QtWebEngineProcess.app inside QtWebEngineCore
+	# is affected, but trying to keep this general in case more slip through in the future.
+	# This is due to a known bug in QT5, and we have to fix up the linked libraries if we're going to have a distributable
+	# result of building. When https://bugreports.qt.io/browse/QTBUG-50155 is fixed, this should be able
+	# to be removed.
 	for j in $(find $i/ -name "*.app"); do
 		EXEC_NAME=$j/Contents/MacOS/$(basename -s ".app" $j)
 		otool -L $EXEC_NAME | grep -o /usr/local.*dylib | while read -a innerlibs ; do


### PR DESCRIPTION
Due to a known bug in QT5, we have to fix up the linked
libraries if we're going to have a (distributable)
result of building. This is already done to a great
extent, but a .app that is included in one of the
frameworks is missed by the current fix. This commit
catches it, and (hopefully) any others that slip through
in the future.

See also:
https://github.com/ethereum/homebrew-ethereum/issues/46
https://github.com/Homebrew/homebrew/issues/47848

This removes the need to follow the workaround described
at

https://github.com/ethereum/webthree-umbrella/wiki/QTBUG-50155-workaround

and restores (I believe) `brew install cpp-ethereum` as a
command that will execute successfully on a clean machine.
