### PR TITLE
use env to determine path for bash

### DIFF
--- a/scripts/ethbuild.sh
+++ b/scripts/ethbuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # author: Lefteris Karapetsas <lefteris@refu.co>
 #
 # A script to build the different ethereum repositories. For usage look

--- a/scripts/ethupdate.sh
+++ b/scripts/ethupdate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # author: Lefteris Karapetsas <lefteris@refu.co>
 #
 # A script to update the different ethereum repositories to latest develop


### PR DESCRIPTION
Not all unix platforms have `bash` installed by default and when they do they are usually installed in `/usr/local/bin/bash` so let's use [env(1)](http://man7.org/linux/man-pages/man1/env.1.html) to determine its path.  
