### PR TITLE
Added --with-d-bus option to Qt5 dependency when we build cpp-ethereum --with-gui

### DIFF
--- a/homebrew/cpp-ethereum.rb.in
+++ b/homebrew/cpp-ethereum.rb.in
@@ -29,18 +29,6 @@ class CppEthereum < Formula
     end
   end
 
-  depends_on 'cmake' => :build
-  depends_on 'boost'
-  depends_on 'qt5' if build.with? 'gui'
-  depends_on 'readline'
-  depends_on 'cryptopp'
-  depends_on 'miniupnpc'
-  depends_on 'leveldb'
-  depends_on 'gmp'
-  depends_on 'curl'
-  depends_on 'libjson-rpc-cpp'
-  depends_on 'homebrew/versions/v8-315'
-
   option "with-gui", "Build with GUI (AlethZero)"
   option "with-evmjit", "Build with LLVM and enable EVMJIT"
   option "without-v8-console", "Build without V8 JavaScript console"
@@ -49,6 +37,18 @@ class CppEthereum < Formula
   option "with-vmtrace", "Build with VMTRACE"
   option "with-paranoia", "Build with -DPARANOID=1"
   option "successful", "Last successful build with --devel only"
+
+  depends_on 'cmake' => :build
+  depends_on 'boost'
+  depends_on 'qt5' => ["with-d-bus"] if build.with? 'gui'
+  depends_on 'readline'
+  depends_on 'cryptopp'
+  depends_on 'miniupnpc'
+  depends_on 'leveldb'
+  depends_on 'gmp'
+  depends_on 'curl'
+  depends_on 'libjson-rpc-cpp'
+  depends_on 'homebrew/versions/v8-315'
 
   def install
     args = *std_cmake_args


### PR DESCRIPTION
Added --with-d-bus option to Qt5 dependency when we build cpp-ethereum --with-gui.

Also reordered the options to be BEFORE the dependencies. My suspicion is that the conditional dependency for Qt5 never actually worked, but that it had never been tested in a clean environment. Looks like build.with? is dependent on those options having been declared, based on local testing of this Formula.
