### PR TITLE
WIP - Remove linkage against Boost chrono and date_time libraries

### DIFF
--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -70,7 +70,7 @@ elseif (UNIX)
 
 endif()
 
-find_package(Boost 1.54.0 QUIET REQUIRED COMPONENTS thread date_time system regex chrono filesystem unit_test_framework program_options random)
+find_package(Boost 1.54.0 QUIET REQUIRED COMPONENTS thread system regex filesystem unit_test_framework program_options random)
 
 eth_show_dependency(Boost boost)
 

--- a/cmake/UseDev.cmake
+++ b/cmake/UseDev.cmake
@@ -11,23 +11,52 @@ function(eth_apply TARGET REQUIRED SUBMODULE)
 
 	# Base is where all dependencies for devcore are
 	if (${SUBMODULE} STREQUAL "base")
-		# if it's ethereum source dir, alwasy build BuildInfo.h before
+		# if it's ethereum source dir, always build BuildInfo.h before
 		eth_use(${TARGET} ${REQUIRED} Dev::buildinfo Jsoncpp)
 		if (NOT EMSCRIPTEN)
 			eth_use(${TARGET} ${REQUIRED} DB::auto)
 		endif()
+
+		# Disable Boost auto-linking, where boost libraries are automatically
+		# added to the link step for platforms which support that feature, which
+		# in our case appears only to be for Windows.   Presumably this is
+		# implemented using #pragma comment(lib ...)
+		#
+		# See https://support.microsoft.com/en-us/kb/153901.
+		#
+		# We don't want this automatic behavior, because it can add libraries
+		# to the link step which we don't actually need or want, depending on
+		# how cleanly #include dependencies have been managed, sometimes within
+		# header files which we don't even author.  It is much better for us
+		# just to manage these dependencies explicitly ourselves.
+		#
+		# See http://www.boost.org/doc/libs/1_40_0/more/getting_started/windows.html#auto-linking
+		#
+		add_definitions(-DBOOST_ALL_NO_LIB)
+
+		# Add Boost include path unconditionally for all modules.
 		target_include_directories(${TARGET} SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
 
+		# NOTE - We are explicitly linking against four different Boost
+		# libraries here unconditionally for every single module within the
+		# Ethereum C++ codebase, with no consideration whatsoever for
+		# the subset of Boost which any particular module is actually
+		# using.   This pattern is particularly unwanted for Solidity,
+		# which doesn't use Boost at all, but which gets the unwanted
+		# heavy-weight dependency, and extra work for the linker.
+		#
+		# These dependencies should be moved up into the build files
+		# for the modules as-and-where they are actually used.
+		#
 		target_link_libraries(${TARGET} ${Boost_THREAD_LIBRARIES})
 		target_link_libraries(${TARGET} ${Boost_RANDOM_LIBRARIES})
 		target_link_libraries(${TARGET} ${Boost_FILESYSTEM_LIBRARIES})
 		target_link_libraries(${TARGET} ${Boost_SYSTEM_LIBRARIES})
 
-		if (DEFINED MSVC)
-			target_link_libraries(${TARGET} ${Boost_CHRONO_LIBRARIES})
-			target_link_libraries(${TARGET} ${Boost_DATE_TIME_LIBRARIES})
-		endif()
-
+		# NOTE - We are also explicitly linking pthread unconditionally
+		# here for all modules on non-Windows platforms, whether or not
+		# they actually use the threading functionality.
+		#
 		if (NOT DEFINED MSVC)
 			target_link_libraries(${TARGET} pthread)
 		endif()


### PR DESCRIPTION
DEPENDS:
{"libweb3core":"fix_boost"
}

It doesn't look like the Boost chrono and date_time libraries (which were only being dragged in for Windows) are actually used at all.   Maybe they were at some stage in the past?   Let's try to remove them.
