### PR TITLE
Partial fix for EVMJIT LLVM bugs

### DIFF
--- a/homebrew/cpp-ethereum.rb.in
+++ b/homebrew/cpp-ethereum.rb.in
@@ -70,7 +70,7 @@ class CppEthereum < Formula
     # args << "-DBUNDLE=release" if build.without? "vmtrace" and build.without? "paranoia"
 
     if build.with? "evmjit"
-      args << "-DLLVM_DIR=/usr/local/opt/llvm/share/llvm/cmake"
+      args << "-DLLVM_DIR=/usr/local/opt/llvm/lib/cmake/llvm"
       args << "-DEVMJIT=1"
       ENV["CXX"] = "/usr/local/opt/llvm/bin/clang++ -stdlib=libc++"
       ENV["CXXFLAGS"] = "#{ENV.cxxflags} -nostdinc++ -I/usr/local/opt/llvm/include/llvm"


### PR DESCRIPTION
Partial fix for https://github.com/ethereum/webthree-umbrella/issues/270.

With the LLVM_DIR in the formula pointing to the wrong place, it isn't possible yet to judge whether the environment variables are redundant, so let's start with this required fix.

CC @chfast.
