### PR TITLE
Removed 'rlp' and 'abi' from the Windows installer.

### DIFF
--- a/cmake/EthExecutableHelper.cmake
+++ b/cmake/EthExecutableHelper.cmake
@@ -215,7 +215,7 @@ macro(eth_nsis)
 			"Mix;Mix"
 		)
 
-		set(CPACK_COMPONENTS_ALL AlethZero AlethOne Mix solc eth ethminer ethkey rlp abi)
+		set(CPACK_COMPONENTS_ALL AlethZero AlethOne Mix solc eth ethminer ethkey)
 
 		include(CPack)
 	endif ()


### PR DESCRIPTION
We are deleting 'rlp' and I have no clue what 'abi' even is.
