### PR TITLE
Enabled warnings-as-errors for our Windows builds

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -24,8 +24,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 	add_compile_options(-Wall)
 	add_compile_options(-Wextra)
 	add_compile_options(-Wno-unknown-pragmas)
-	add_compile_options(-Wno-unused-function)              # Needed for sepc256k1
-	add_compile_options(-Wno-dangling-else)                # (clog, cwarn) macros
+	add_compile_options(-Wno-unused-function)			# Needed for sepc256k1
+	add_compile_options(-Wno-dangling-else)				# (clog, cwarn) macros
 	add_compile_options(-fPIC)
 	add_compile_options(-fstack-protector-strong)
 	add_compile_options(-fstack-protector)
@@ -62,21 +62,21 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
 elseif (DEFINED MSVC)
 
-	# enable parallel compilation
-	# specify Exception Handling Model in msvc
-	# disable unknown pragma warning (4068)
-	# disable unsafe function warning (4996)
-	# disable decorated name length exceeded, name was truncated (4503)
-	# disable conversion from 'size_t' to 'type', possible loss of data (4267)
-	# disable qualifier applied to function type has no meaning; ignored (4180)
-	# disable C++ exception specification ignored except to indicate a function is not __declspec(nothrow) (4290)
-	# disable conversion from 'type1' to 'type2', possible loss of data (4244)
-	# disable forcing value to bool 'true' or 'false' (performance warning) (4800)
-	# disable warning C4535: calling _set_se_translator() requires /EHa (for boost tests)
-	# declare Windows Vista API requirement
-	# undefine windows.h MAX && MIN macros cause it cause conflicts with std::min && std::max functions
-	# define miniupnp static library
-	add_compile_options(/MP /EHsc /wd4068 /wd4996 /wd4503 /wd4267 /wd4180 /wd4290 /wd4244 /wd4800 -D_WIN32_WINNT=0x0600 /DNOMINMAX /DMINIUPNP_STATICLIB)
+    add_compile_options(/MP)						# enable parallel compilation
+	add_compile_options(/EHsc)						# specify Exception Handling Model in msvc
+	add_compile_options(/WX)						# enable warnings-as-errors
+	add_compile_options(/wd4068)					# disable unknown pragma warning (4068)
+	add_compile_options(/wd4996)					# disable unsafe function warning (4996)
+	add_compile_options(/wd4503)					# disable decorated name length exceeded, name was truncated (4503)
+	add_compile_options(/wd4267)					# disable conversion from 'size_t' to 'type', possible loss of data (4267)
+	add_compile_options(/wd4180)					# disable qualifier applied to function type has no meaning; ignored (4180)
+	add_compile_options(/wd4290)					# disable C++ exception specification ignored except to indicate a function is not __declspec(nothrow) (4290)
+	add_compile_options(/wd4244)					# disable conversion from 'type1' to 'type2', possible loss of data (4244)
+	add_compile_options(/wd4800)					# disable forcing value to bool 'true' or 'false' (performance warning) (4800)
+	add_compile_options(-D_WIN32_WINNT=0x0600)		# declare Windows Vista API requirement
+	add_compile_options(-DNOMINMAX)					# undefine windows.h MAX && MIN macros cause it cause conflicts with std::min && std::max functions
+	add_compile_options(-DMINIUPNP_STATICLIB)		# define miniupnp static library
+
 	# disable empty object file warning
 	set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /ignore:4221")
 	# warning LNK4075: ignoring '/EDITANDCONTINUE' due to '/SAFESEH' specification


### PR DESCRIPTION
All outstanding Windows warnings were fixed or suppressed in previous commits.
Also split the global warning suppressions in webthree-helpers onto a line each, for ease of comprehension.
We have way too many of them, and some may be masking real issues.
This commit is a partial fix for https://github.com/ethereum/webthree-umbrella/issues/219
