### PR TITLE
More "mix" to "mix-ide" renaming, aiming to address build breaks.

### DIFF
--- a/cmake/EthExecutableHelper.cmake
+++ b/cmake/EthExecutableHelper.cmake
@@ -209,10 +209,10 @@ macro(eth_nsis)
 		set(CPACK_NSIS_EXECUTABLES_DIRECTORY ".")
 		set(CPACK_PACKAGE_EXECUTABLES
 			"AlethZero;AlethZero"
-			"Mix;Mix"
+			"Mix;Mix-ide"
 		)
 
-		set(CPACK_COMPONENTS_ALL AlethZero Mix solc eth ethminer ethkey)
+		set(CPACK_COMPONENTS_ALL AlethZero Mix-ide solc eth ethminer ethkey)
 
 		include(CPack)
 	endif ()
@@ -230,7 +230,7 @@ macro(eth_appdmg)
 			-DAPP_DMG_BACKGROUND="${CMAKE_CURRENT_SOURCE_DIR}/res/mac/install-folder-bg@2x.png"
 			-DETH_BUILD_DIR="${CMAKE_BINARY_DIR}"
 			-DETH_ALETHZERO_APP="$<TARGET_FILE_DIR:AlethZero>"
-			-DETH_MIX_APP="$<TARGET_FILE_DIR:Mix>"
+			-DETH_MIX_APP="$<TARGET_FILE_DIR:Mix-ide>"
 			-P "${ETH_SCRIPTS_DIR}/appdmg.cmake"
 		)
 	endif()

--- a/homebrew/cpp-ethereum.rb.in
+++ b/homebrew/cpp-ethereum.rb.in
@@ -80,7 +80,7 @@ class CppEthereum < Formula
 
     if build.with? "gui"
       prefix.install 'alethzero/alethzero/AlethZero.app'
-      prefix.install 'mix/Mix.app'
+      prefix.install 'mix/Mix-ide.app'
     end
   end
 

--- a/scripts/ethbuild.sh
+++ b/scripts/ethbuild.sh
@@ -26,7 +26,7 @@ REPOS_MSVC_SLN_MAP=("webthree-helpers/utils:utils.sln"
 	"webthree:webthree.sln"
 	"solidity:solidity.sln"
 	"alethzero:alethzero.sln"
-	"mix:mix.sln"
+	"mix:mix-ide.sln"
 )
 
 function get_repo_sln() {

--- a/scripts/ethbuild.sh
+++ b/scripts/ethbuild.sh
@@ -26,7 +26,7 @@ REPOS_MSVC_SLN_MAP=("webthree-helpers/utils:utils.sln"
 	"webthree:webthree.sln"
 	"solidity:solidity.sln"
 	"alethzero:alethzero.sln"
-	"mix:mix-ide.sln"
+	"mix:mix.sln"
 )
 
 function get_repo_sln() {


### PR DESCRIPTION
Some of these are "best guess" and untested, but the OS X one is to address a blatant build break for OS X.
These changes are related to https://github.com/ethereum/webthree-umbrella/issues/449
