### PR TITLE
Added code to the CMake files to set ETH_EVMJIT and ETH_FATDB pre-processor symbols to the compiler invocation.

### DIFF
--- a/cmake/EthOptions.cmake
+++ b/cmake/EthOptions.cmake
@@ -18,23 +18,49 @@ macro(configure_project)
 	eth_default_option(EVMJIT ON)
 	eth_default_option(SOLIDITY ON)
 
+	# Resolve any clashes between incompatible options.
+	if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+		if (PARANOID)
+			message("Paranoia requires debug - disabling for release build.")
+			set(PARANOID OFF)
+		endif ()
+		if (VMTRACE)
+			message("VM Tracing requires debug - disabling for release build.")
+			set (VMTRACE OFF)
+		endif ()
+	endif ()
+
+	# Define a matching property name of each of the "features".
 	foreach(FEATURE ${ARGN})
 		set(SUPPORT_${FEATURE} TRUE)
 	endforeach()
 
-	# propagates CMake configuration options to the compiler
+	# TODO:  Eliminate this pre-processor symbol, which is a bad pattern.
+	# Common code has no business knowing which application it is part of.
+	add_definitions(-DETH_TRUE)
+
+	# TODO:  Why do we even bother with Olympic support anymore?
 	if (OLYMPIC)
 		add_definitions(-DETH_OLYMPIC)
 	else()
 		add_definitions(-DETH_FRONTIER)
 	endif()
 
-	add_definitions(-DETH_TRUE)
+	if (EVMJIT)
+		add_definitions(-DETH_EVMJIT)
+	endif ()
 
+	# TODO:  What does "fat DB" even mean?
+	if (FATDB)
+		add_definitions(-DETH_FATDB)
+	endif ()
+
+	# TODO:  What does "paranoia" even mean?
 	if (PARANOID)
 		add_definitions(-DETH_PARANOIA)
 	endif ()
 
+	# TODO:  What does "VM trace" even mean?
 	if (VMTRACE)
 		add_definitions(-DETH_VMTRACE)
 	endif ()
@@ -48,23 +74,14 @@ macro(configure_project)
 		# Windows max version component number is 65535
 		set(BUILD_NUMBER 65535)
 	endif()
+
 	# Suffix like "-rc1" e.t.c. to append to versions wherever needed.
 	if (NOT DEFINED VERSION_SUFFIX)
 		set(VERSION_SUFFIX "")
 	endif()
-	set (PROJECT_VERSION_TWEAK ${BUILD_NUMBER})
 
-	# Clear invalid option
-	if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
-		if (PARANOID)
-			message("Paranoia requires debug - disabling for release build.")
-			set(PARANOID OFF)
-		endif ()
-		if (VMTRACE)
-			message("VM Tracing requires debug - disabling for release build.")
-			set (VMTRACE OFF)
-		endif ()
-	endif ()
+	# TODO:  How is this used, if at all?
+	set (PROJECT_VERSION_TWEAK ${BUILD_NUMBER})
 
 	include(EthBuildInfo)
 	create_build_info(${NAME})


### PR DESCRIPTION
We were previously only adding them to the generated ConfigInfo.h file for some reason.
This way we can start stripping the ConfigInfo.h includes out from the codebase, and then eliminate that generated header entirely.
