### PR TITLE
Revert "Another try at fixing mix package."

### DIFF
--- a/cmake/EthExecutableHelper.cmake
+++ b/cmake/EthExecutableHelper.cmake
@@ -212,7 +212,7 @@ macro(eth_nsis)
 			"Mix-ide;Mix"
 		)
 
-		set(CPACK_COMPONENTS_ALL AlethZero Mix-ide solc eth ethminer ethkey)
+		set(CPACK_COMPONENTS_ALL AlethZero Mix solc eth ethminer ethkey)
 
 		include(CPack)
 	endif ()


### PR DESCRIPTION
Reverts ethereum/webthree-helpers#140

This results in an error about an "invalid variable name", apparently cpack/nsis stumbles over the `-`.
