### PR TITLE
Using ruby script.rb, rather than unqualified script.rb, to attempt to resolve Jenkins breaks.

### DIFF
--- a/scripts/ethbinaries.sh
+++ b/scripts/ethbinaries.sh
@@ -173,10 +173,10 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
 		cp ./install/lib/*.dylib ethbin/
 		cp ./install/bin/eth ethbin/
 		cd ethbin
-		../../webthree-helpers/scripts/locdep.rb eth .
-		for f in *.dylib ; do ../../webthree-helpers/scripts/locdep.rb $f . ; done
+		ruby ../../webthree-helpers/scripts/locdep.rb eth .
+		for f in *.dylib ; do ruby ../../webthree-helpers/scripts/locdep.rb $f . ; done
 		# run again to process dylibs copied on previous step
-		for f in *.dylib ; do ../../webthree-helpers/scripts/locdep.rb $f . ; done
+		for f in *.dylib ; do ruby ../../webthree-helpers/scripts/locdep.rb $f . ; done
 		cd ..
 		zip eth_standalone_osx.zip ethbin/*
 


### PR DESCRIPTION
OS X Yosemite and El Capitan seemingly come with Ruby 2.0 installed by default, which is too new for our locdep.rb script
The workaround is to install Ruby 1.9.3 on the build machine, following these instructions:
http://blog.zerosharp.com/installing-ruby-with-homebrew-and-rbenv-on-mac-os-x-mountain-lion/
