### PR TITLE
Update leveldb from 1.2 to 1.18.

### DIFF
--- a/extdep/getstuff.bat
+++ b/extdep/getstuff.bat
@@ -10,7 +10,7 @@ call :download cryptopp 5.6.2
 call :download curl 7.4.2
 call :download jsoncpp 1.6.2
 call :download json-rpc-cpp 0.5.0
-call :download leveldb 1.2
+call :download leveldb 1.18
 call :download llvm 3.7.0
 call :download microhttpd 0.9.2
 call :download OpenCL_ICD 1


### PR DESCRIPTION
Connects to https://github.com/ethereum/webthree-umbrella/issues/468
