### PR TITLE
Solidity self reference

### DIFF
--- a/cmake/UseSolidity.cmake
+++ b/cmake/UseSolidity.cmake
@@ -6,7 +6,11 @@ function(eth_apply TARGET REQUIRED SUBMODULE)
 	set(CMAKE_LIBRARY_PATH ${SOL_BUILD_DIR};${CMAKE_LIBRARY_PATH})
 
 	find_package(Solidity)
-	eth_show_dependency(SOLIDITY solidity)
+
+	# Hide confusing blank dependency information when using FindSolidity on itself.
+	if (NOT(${MODULE_MAIN} STREQUAL Solidity))
+		eth_show_dependency(SOLIDITY solidity)
+	endif()
 
 	target_include_directories(${TARGET} PUBLIC ${Solidity_INCLUDE_DIRS})
 

--- a/extdep/getstuff.bat
+++ b/extdep/getstuff.bat
@@ -10,7 +10,7 @@ call :download cryptopp 5.6.2
 call :download curl 7.4.2
 call :download jsoncpp 1.6.2
 call :download json-rpc-cpp 0.5.0
-call :download leveldb 1.2
+call :download leveldb 1.18
 call :download llvm 3.7.0
 call :download microhttpd 0.9.2
 call :download OpenCL_ICD 1


### PR DESCRIPTION
Hide confusing blank dependency information when using FindSolidity on itself.
This fixes https://github.com/ethereum/webthree-umbrella/issues/465.
