### PR TITLE
more useful arg order for finding packages

### DIFF
--- a/cmake/FindCURL.cmake
+++ b/cmake/FindCURL.cmake
@@ -52,6 +52,6 @@ endif()
 # if all listed variables are TRUE, hide their existence from configuration view
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(CURL DEFAULT_MSG
-	CURL_INCLUDE_DIR CURL_LIBRARY)
+	CURL_LIBRARY CURL_INCLUDE_DIR)
 mark_as_advanced (CURL_INCLUDE_DIR CURL_LIBRARY)
 

--- a/cmake/FindCpuid.cmake
+++ b/cmake/FindCpuid.cmake
@@ -28,6 +28,6 @@ set(CPUID_LIBRARIES ${CPUID_LIBRARY})
 # handle the QUIETLY and REQUIRED arguments and set CPUID_FOUND to TRUE
 # if all listed variables are TRUE, hide their existence from configuration view
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Cpuid DEFAULT_MSG CPUID_INCLUDE_DIR CPUID_LIBRARY)
+find_package_handle_standard_args(Cpuid DEFAULT_MSG CPUID_LIBRARY CPUID_INCLUDE_DIR)
 mark_as_advanced (CPUID_INCLUDE_DIR CPUID_LIBRARY)
 

--- a/cmake/FindGmp.cmake
+++ b/cmake/FindGmp.cmake
@@ -29,6 +29,6 @@ set(GMP_LIBRARIES ${GMP_LIBRARY})
 # if all listed variables are TRUE, hide their existence from configuration view
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(gmp DEFAULT_MSG
-	GMP_INCLUDE_DIR GMP_LIBRARY)
+	GMP_LIBRARY GMP_INCLUDE_DIR)
 mark_as_advanced (GMP_INCLUDE_DIR GMP_LIBRARY)
 

--- a/cmake/FindJsoncpp.cmake
+++ b/cmake/FindJsoncpp.cmake
@@ -45,6 +45,6 @@ endif()
 # if all listed variables are TRUE, hide their existence from configuration view
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(jsoncpp DEFAULT_MSG
-	JSONCPP_INCLUDE_DIR JSONCPP_LIBRARY)
+	JSONCPP_LIBRARY JSONCPP_INCLUDE_DIR)
 mark_as_advanced (JSONCPP_INCLUDE_DIR JSONCPP_LIBRARY)
 

--- a/cmake/FindLevelDB.cmake
+++ b/cmake/FindLevelDB.cmake
@@ -45,6 +45,6 @@ endif()
 # if all listed variables are TRUE, hide their existence from configuration view
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(leveldb DEFAULT_MSG
-	LEVELDB_INCLUDE_DIR LEVELDB_LIBRARY)
+	LEVELDB_LIBRARY LEVELDB_INCLUDE_DIR)
 mark_as_advanced (LEVELDB_INCLUDE_DIR LEVELDB_LIBRARY)
 

--- a/cmake/FindMHD.cmake
+++ b/cmake/FindMHD.cmake
@@ -49,6 +49,6 @@ endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(mhd DEFAULT_MSG
-	MHD_INCLUDE_DIR MHD_LIBRARY)
+	MHD_LIBRARY MHD_INCLUDE_DIR)
 
 mark_as_advanced(MHD_INCLUDE_DIR MHD_LIBRARY)

--- a/cmake/FindMiniupnpc.cmake
+++ b/cmake/FindMiniupnpc.cmake
@@ -44,6 +44,6 @@ endif()
 # if all listed variables are TRUE, hide their existence from configuration view
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(miniupnpc DEFAULT_MSG
-	MINIUPNPC_INCLUDE_DIR MINIUPNPC_LIBRARY)
+	MINIUPNPC_LIBRARY MINIUPNPC_INCLUDE_DIR)
 mark_as_advanced (MINIUPNPC_INCLUDE_DIR MINIUPNPC_LIBRARY)
 

--- a/cmake/FindRocksDB.cmake
+++ b/cmake/FindRocksDB.cmake
@@ -44,6 +44,6 @@ endif()
 # if all listed variables are TRUE, hide their existence from configuration view
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(RocksDB DEFAULT_MSG
-	ROCKSDB_INCLUDE_DIR ROCKSDB_LIBRARY)
+	ROCKS_DB_LIBRARY ROCKSDB_INCLUDE_DIR)
 mark_as_advanced (ROCKSDB_INCLUDE_DIR ROCKSDB_LIBRARY)
 


### PR DESCRIPTION
Swap the order of LIBRARY / INCLUDE supplied to cmake package finder.

The original ordering results in less useful configuration output.

Before:

```
-- Found CURL: /usr/lib/include
-- curl headers: /usr/include
-- curl lib   : /usr/lib/libcurl.a
```

After:

```
-- Found CURL: /usr/lib/libcurl.a
-- curl headers: /usr/include
-- curl lib   : /usr/lib/libcurl.a
```

Note that 'Found CURL' now points to the library path rather than the include dir.

This is the order used in CMake supplied FindFoo modules, e.g. in FindOpenSSL, which gives us

```
-- Found OpenSSL: /usr/lib/libssl.a;/usr/lib/libcrypto.a (found version "1.0.2g")
-- OpenSSL headers: /usr/include
-- OpenSSL lib   : /usr/lib/libssl.a;/usr/lib/libcrypto.a
```

I looked in the history to see if there was any reasoning for having it the other way around, but couldn't see anything.
