### PR TITLE
make curl dependency link modular

### DIFF
--- a/cmake/UseCURL.cmake
+++ b/cmake/UseCURL.cmake
@@ -1,0 +1,11 @@
+function(eth_apply TARGET REQUIRED)
+	find_package (CURL)
+	eth_show_dependency(CURL curl)
+
+	if (CURL_FOUND)
+		target_include_directories(${TARGET} SYSTEM PUBLIC ${CURL_INCLUDE_DIRS})
+		target_link_libraries(${TARGET} ${CURL_LIBRARIES})
+	elseif (NOT ${REQUIRED} STREQUAL "OPTIONAL")
+		message(FATAL_ERROR "Curl library not found")
+	endif()
+endfunction()

--- a/cmake/UseJsonRpc.cmake
+++ b/cmake/UseJsonRpc.cmake
@@ -4,8 +4,8 @@ function(eth_apply TARGET REQUIRED SUBMODULE)
 	find_package (json_rpc_cpp 0.4)
 	find_program(ETH_JSON_RPC_STUB jsonrpcstub)
 	eth_show_dependency(JSON_RPC_CPP json-rpc-cpp)
-	find_package(CURL)
-	eth_show_dependency(CURL curl)
+
+	eth_use(${TARGET} ${REQUIRED} CURL)
 
 	if (${SUBMODULE} STREQUAL "Server")
 		eth_use(${TARGET} ${REQUIRED} Mhd)
@@ -21,9 +21,7 @@ function(eth_apply TARGET REQUIRED SUBMODULE)
 
 	if (${SUBMODULE} STREQUAL "Client")
 		target_include_directories(${TARGET} SYSTEM PUBLIC ${JSON_RPC_CPP_INCLUDE_DIRS})
-		target_include_directories(${TARGET} SYSTEM PUBLIC ${CURL_INCLUDE_DIRS})
 		target_link_libraries(${TARGET} ${JSON_RPC_CPP_CLIENT_LIBRARIES})
-		target_link_libraries(${TARGET} ${CURL_LIBRARIES})
 		target_compile_definitions(${TARGET} PUBLIC ETH_JSONRPC)
 
 		eth_copy_dlls(${TARGET} CURL_DLLS)


### PR DESCRIPTION
Will allow us to more easily reason with system dependencies, with the aim of allowing full static linking.
