### PR TITLE
Specify full curl dependencies

### DIFF
--- a/cmake/UseCURL.cmake
+++ b/cmake/UseCURL.cmake
@@ -3,6 +3,10 @@ function(eth_apply TARGET REQUIRED)
 	eth_show_dependency(CURL curl)
 
 	if (CURL_FOUND)
+		eth_use(${TARGET} OPTIONAL SSH2)
+		eth_use(${TARGET} OPTIONAL OpenSSL)
+		eth_use(${TARGET} OPTIONAL ZLIB)
+
 		target_include_directories(${TARGET} SYSTEM PUBLIC ${CURL_INCLUDE_DIRS})
 		target_link_libraries(${TARGET} ${CURL_LIBRARIES})
 	elseif (NOT ${REQUIRED} STREQUAL "OPTIONAL")


### PR DESCRIPTION
Let curl know what its dependencies are. I'm not sure ssh2 is strictly necessary - might vary depending on curl install.
