### PR TITLE
add static link logic

### DIFF
--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -70,6 +70,23 @@ elseif (UNIX)
 
 endif()
 
+set(STATIC_LINKING FALSE CACHE BOOL "Build static binaries")
+
+if(STATIC_LINKING)
+	set(Boost_USE_STATIC_LIBS ON)
+	set(Boost_USE_STATIC_RUNTIME ON)
+
+	set(OpenSSL_USE_STATIC_LIBS ON)
+
+	if(MSVC)
+		set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+	else()
+		set(CMAKE_FIND_LIBRARY_SUFFIXES .a )
+	endif()
+
+	set(ETH_STATIC ON)
+endif()
+
 find_package(Boost 1.54.0 QUIET REQUIRED COMPONENTS thread date_time system regex chrono filesystem unit_test_framework program_options random)
 
 eth_show_dependency(Boost boost)

--- a/cmake/EthExecutableHelper.cmake
+++ b/cmake/EthExecutableHelper.cmake
@@ -43,6 +43,16 @@ macro(eth_add_executable EXECUTABLE)
 
 endmacro()
 
+macro(eth_simple_add_executable EXECUTABLE SRC_LIST HEADERS)
+	add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
+
+	if (STATIC_LINKING)
+		set(CMAKE_EXE_LINKER_FLAGS "-static ${CMAKE_EXE_LINKER_FLAGS}")
+		set_target_properties(${EXECUTABLE} PROPERTIES LINK_SEARCH_START_STATIC 1)
+		set_target_properties(${EXECUTABLE} PROPERTIES LINK_SEARCH_END_STATIC 1)
+	endif()
+endmacro()
+
 macro(eth_copy_dll EXECUTABLE DLL)
 	# dlls must be unsubstitud list variable (without ${}) in format
 	# optimized;path_to_dll.dll;debug;path_to_dlld.dll


### PR DESCRIPTION
This lets us put the static options around the add_executable. 

I've added a new macro rather than repurpose `eth_add_executable` as I'm not completely confident in what it does - seems to be some Apple UI magic happening. Any ideas?

Need changes outside of webthree-helpers for this to do anything.
