### PR TITLE
Fix macro arguments.

### DIFF
--- a/cmake/EthExecutableHelper.cmake
+++ b/cmake/EthExecutableHelper.cmake
@@ -43,7 +43,7 @@ macro(eth_add_executable EXECUTABLE)
 
 endmacro()
 
-macro(eth_simple_add_executable EXECUTABLE SRC_LIST HEADERS)
+macro(eth_simple_add_executable EXECUTABLE)
 	add_executable(${EXECUTABLE} ${SRC_LIST} ${HEADERS})
 
 	if (STATIC_LINKING)


### PR DESCRIPTION
Messed up on #163 with the macro arguments.

CMake macros are not functions: macros have directory scope, so you don't need to pass them arguments.

The previous way fails if one of SRC / HEADERS is empty (as for `lllc`)
