### PR TITLE
Edits to prepare_receipt.sh to update existing cpp-ethereum.rb, rather than re-generated from the template each time

### DIFF
--- a/homebrew/prepare_receipt.sh
+++ b/homebrew/prepare_receipt.sh
@@ -5,6 +5,17 @@
 VERSION=1 # eg 1.0rc2
 NUMBER=1 # jenkins build number
 
+# Detect whether we are running on a Yosemite or El Capitan machine, and generate
+# an appropriately named ZIP file for the Homebrew receipt to point at.
+if echo `sw_vers` | grep "10.11"; then
+    OSX_VERSION=elcapitan
+elif echo `sw_vers` | grep "10.10"; then
+    OSX_VERSION=yosemite
+else
+    echo Unsupported OS X version.  We only support Yosemite and El Capitan
+    exit 1
+fi
+
 while [ "$1" != "" ]; do
     case $1 in
         --version )
@@ -27,20 +38,27 @@ p="../webthree-helpers/homebrew/"
 cp ${p}homebrew.mxcl.cpp-ethereum.plist ${p}INSTALL_RECEIPT.json ${p}LICENSE ${p}README.md cpp-ethereum/$VERSION
 
 # build umbrella project and move install directory to destination
+#
+# TODO - Except it isn't actually building it is? Maybe it used to
+# at some point in the past? Does that mean that we are dependent
+# on some previous build/install steps having happened by the time
+# we run this script? Probably.
 mkdir -p install
 cp -rf install/* cpp-ethereum/$VERSION
 
-#tar everything
-NAME="cpp-ethereum-${VERSION}.yosemite.bottle.${NUMBER}.tar.gz"
+# tar everything
+NAME="cpp-ethereum-${VERSION}.${OSX_VERSION}.bottle.${NUMBER}.tar.gz"
 tar -zcvf $NAME cpp-ethereum
 
 # get variables
 HASH=`git rev-parse HEAD`
 SIGNATURE=`openssl sha1 ${NAME} | cut -d " " -f 2`
 
-# prepare receipt
-sed -e s/CFG_NUMBER/${NUMBER}/g \
-    -e s/CFG_SIGNATURE/${SIGNATURE}/g \
-    -e s/CFG_HASH/${HASH}/g \
-    -e s/CFG_VERSION/${VERSION}/g < ${p}cpp-ethereum.rb.in > "cpp-ethereum.rb"
+# Pull the current cpp-ethereum.rb file from Github.  We used to use a template file.
+curl https://raw.githubusercontent.com/ethereum/homebrew-ethereum/master/cpp-ethereum.rb > cpp-ethereum.rb.in
 
+# prepare receipt
+sed -e s/revision\ \=\>\ \'[[:xdigit:]][[:xdigit:]]*\'/revision\ \=\>\ \'${SIGNATURE}\'/g \
+    -e s/version\ \'.*\'/version\ \'${VERSION}\'/g \
+    -e s/sha1\ \'[[:xdigit:]][[:xdigit:]]*\'\ \=\>\ \:${OSX_VERSION}/sha1\ \'${HASH}\'\ \=\>\ \:${OSX_VERSION}/g \
+    -e s/revision[[:space:]][[:digit:]][[:digit:]]*/revision\ ${NUMBER}/g < cpp-ethereum.rb.in > "cpp-ethereum-new.rb"


### PR DESCRIPTION
That change is required to support Yosemite and El Capitan builds in parallel.
