### PR TITLE
Switched around Homebrew logic on EVMJIT, which I suspect to be OFF by default

### DIFF
--- a/homebrew/cpp-ethereum.rb.in
+++ b/homebrew/cpp-ethereum.rb.in
@@ -1,7 +1,21 @@
+#------------------------------------------------------------------------------
+# cpp-ethereum.rb
+#
+# Homebrew formula for cpp-ethereum.  Homebrew (http://brew.sh/) is
+# the de-facto standard package manager for OS X, and this Ruby script
+# contains the metadata used to map command-line user settings used
+# with the 'brew' command onto build options.
+#
+# Our docummentation for the cpp-ethereum Homebrew setup is at:
+#
+# http://www.ethdocs.org/en/latest/ethereum-clients/cpp-ethereum/installing-binaries/osx-homebrew.html
+#
+# (c) 2014-2016 cpp-ethereum contributors.
+#------------------------------------------------------------------------------
+
 require 'formula'
 
 class CppEthereum < Formula
-  # official_version-protocol_version-database_version
   version 'CFG_VERSION'
 
   homepage 'https://github.com/ethereum/webthree-umbrella'
@@ -30,8 +44,7 @@ class CppEthereum < Formula
   end
 
   option "with-gui", "Build with GUI (AlethZero)"
-  option "with-evmjit", "Build with LLVM and enable EVMJIT"
-  option "without-gpu-mining", "Build without OpenCL GPU mining (experimental)"
+  option "without-evmjit", "Build without JIT (and its LLVM dependency)"
   option "with-debug", "Build with debug"
   option "with-vmtrace", "Build with VMTRACE"
   option "with-paranoia", "Build with -DPARANOID=1"
@@ -57,10 +70,10 @@ class CppEthereum < Formula
       args << "-DCMAKE_BUILD_TYPE=Release"
     end
 
-    if build.with? "evmjit"
-      args << "-DEVMJIT=1"
-    else
+    if build.without? "evmjit"
       args << "-DEVMJIT=0"
+    else
+      args << "-DEVMJIT=1"
     end
 
     if build.with? "gui"
@@ -70,7 +83,6 @@ class CppEthereum < Formula
       args << "-DGUI=0"
     end
 
-    args << "-DETHASHCL=0" if build.without? "gpu-mining"
     args << "-DVMTRACE=1" if build.with? "vmtrace"
     args << "-DPARANOID=1" if build.with? "paranoia"
 


### PR DESCRIPTION
Added a block comment header to cpp-ethereum.rb.in.
Removed the "build without gpu mining" option here.
I don't think we need to offer that flexibility to end-users via Homebrew.
Indeed, there are more options here which should probably be removed over time as well.
