### PR TITLE
Integrate dependencies for Visual Studio 2015

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps"]
+	path = deps
+	url = https://github.com/ethereum/cpp-dependencies

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -147,6 +147,17 @@ elseif (DEFINED MSVC)
 	add_compile_options(-DNOMINMAX)					# undefine windows.h MAX && MIN macros cause it cause conflicts with std::min && std::max functions
 	add_compile_options(-DMINIUPNP_STATICLIB)		# define miniupnp static library
 
+	# Always use Release variant of C++ runtime.
+	# We don't want to provide Debug variants of all dependencies. Some default
+	# flags set by CMake must be tweaked.
+	string(REPLACE "/MDd" "/MD" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+	string(REPLACE "/D_DEBUG" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+	string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+	string(REPLACE "/MDd" "/MD" CMAKE_C_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG})
+	string(REPLACE "/D_DEBUG" "" CMAKE_C_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG})
+	string(REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG})
+	set_property(GLOBAL PROPERTY DEBUG_CONFIGURATIONS OFF)
+
 	# disable empty object file warning
 	set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /ignore:4221")
 	# warning LNK4075: ignoring '/EDITANDCONTINUE' due to '/SAFESEH' specification

--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -21,7 +21,11 @@ if (DEFINED MSVC)
 		set (ETH_DEPENDENCY_INSTALL_DIR "${CMAKE_CURRENT_LIST_DIR}/../extdep/install/windows/x64")
 	else()
 		get_filename_component(DEPS_DIR "${CMAKE_CURRENT_LIST_DIR}/../deps/install" ABSOLUTE)
-		set(ETH_DEPENDENCY_INSTALL_DIR "${DEPS_DIR}/x64" "${DEPS_DIR}/win64/Release/share")
+		set(ETH_DEPENDENCY_INSTALL_DIR
+			"${DEPS_DIR}/x64"					# Old location for deps.
+			"${DEPS_DIR}/win64"					# New location for deps.
+			"${DEPS_DIR}/win64/Release/share"	# LLVM shared cmake files.
+		)
 	endif()
 	set (CMAKE_PREFIX_PATH ${ETH_DEPENDENCY_INSTALL_DIR} ${CMAKE_PREFIX_PATH})
 

--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -16,7 +16,13 @@ endfunction()
 if (DEFINED MSVC)
 	# by defining CMAKE_PREFIX_PATH variable, cmake will look for dependencies first in our own repository before looking in system paths like /usr/local/ ...
 	# this must be set to point to the same directory as $ETH_DEPENDENCY_INSTALL_DIR in /extdep directory
-	set (ETH_DEPENDENCY_INSTALL_DIR "${CMAKE_CURRENT_LIST_DIR}/../extdep/install/windows/x64")
+
+	if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.0.0)
+		set (ETH_DEPENDENCY_INSTALL_DIR "${CMAKE_CURRENT_LIST_DIR}/../extdep/install/windows/x64")
+	else()
+		get_filename_component(DEPS_DIR "${CMAKE_CURRENT_LIST_DIR}/../deps/install" ABSOLUTE)
+		set(ETH_DEPENDENCY_INSTALL_DIR "${DEPS_DIR}/x64" "${DEPS_DIR}/win64/Release/share")
+	endif()
 	set (CMAKE_PREFIX_PATH ${ETH_DEPENDENCY_INSTALL_DIR} ${CMAKE_PREFIX_PATH})
 
 	# Qt5 requires opengl

--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -125,21 +125,10 @@ set(OpenCL_LIBRARIES ${OpenCL_LIBRARY})
 set(OpenCL_INCLUDE_DIRS ${OpenCL_INCLUDE_DIR})
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-
-	find_library(
-		OpenCL_LIBRARY_DEBUG
-		NAMES OpenCL_d
-	)
-
-	set(OpenCL_LIBRARIES optimized ${OpenCL_LIBRARY} debug ${OpenCL_LIBRARY_DEBUG})
-
 	# prepare dlls
 	string(REPLACE ".lib" ".dll" OpenCL_DLL ${OpenCL_LIBRARY})
 	string(REPLACE "/lib/" "/bin/" OpenCL_DLL ${OpenCL_DLL})
-	string(REPLACE ".lib" ".dll" OpenCL_DLL_DEBUG ${OpenCL_LIBRARY_DEBUG})
-	string(REPLACE "/lib/" "/bin/" OpenCL_DLL_DEBUG ${OpenCL_DLL_DEBUG})
-	set(OpenCL_DLLS optimized ${OpenCL_DLL} debug ${OpenCL_DLL_DEBUG})
-
+	set(OpenCL_DLLS optimized ${OpenCL_DLL} debug ${OpenCL_DLL})
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)


### PR DESCRIPTION
This PR contains actually 2 changes:
1. I want to distribute deps for MSVC 2015 a bit differently so I placed them in `deps` folder.
2. The Release variant of C++ runtime is used for Debug build. We will loose some runtime checks but we should be fine without them.
