### PR TITLE
Removed accidental unconditional dependency on CURL.

### DIFF
--- a/cmake/UseJsonRpc.cmake
+++ b/cmake/UseJsonRpc.cmake
@@ -5,8 +5,6 @@ function(eth_apply TARGET REQUIRED SUBMODULE)
 	find_program(ETH_JSON_RPC_STUB jsonrpcstub)
 	eth_show_dependency(JSON_RPC_CPP json-rpc-cpp)
 
-	eth_use(${TARGET} ${REQUIRED} CURL)
-
 	if (${SUBMODULE} STREQUAL "Server")
 		eth_use(${TARGET} ${REQUIRED} Mhd)
 		get_property(DISPLAYED GLOBAL PROPERTY ETH_JSONRPCSTUB_DISPLAYED)
@@ -24,6 +22,7 @@ function(eth_apply TARGET REQUIRED SUBMODULE)
 		target_link_libraries(${TARGET} ${JSON_RPC_CPP_CLIENT_LIBRARIES})
 		target_compile_definitions(${TARGET} PUBLIC ETH_JSONRPC)
 
+		eth_use(${TARGET} ${REQUIRED} CURL)
 		eth_copy_dlls(${TARGET} CURL_DLLS)
 	endif()
 


### PR DESCRIPTION
It appears that the nesting was always wrong, but we used to be able to get away with it when the code was using explicit find_package(), target_include_directories() and target_link_libraries() calls.   Now that the dependency onto CURL is a "normal" eth_use, the issue was exposed, resulting in an unwanted CURL dependency on any system which had CURL installed.
