### PR TITLE
Disable EVMJIT by default.

### DIFF
--- a/cmake/EthOptions.cmake
+++ b/cmake/EthOptions.cmake
@@ -21,7 +21,7 @@ macro(configure_project)
 	eth_default_option(TESTS ON)
 	eth_default_option(TOOLS ON)
 	eth_default_option(ETHASHCL ON)
-	eth_default_option(EVMJIT ON)
+	eth_default_option(EVMJIT OFF)
 	eth_default_option(SOLIDITY ON)
 
 	# Resolve any clashes between incompatible options.


### PR DESCRIPTION
The LLVM team disabled the apt-get support on their server, breaking anybody who was relying on that (including us), so our Ubuntu build instructions are actually broken right now.    In the short term we will just disable EVMJIT, which removes that LLVM dependency too.     We can revisit that decision when we have a viable answer on how to get LLVM back (which probably means adding it to our PPA).    Removing EVMJIT in this way makes building cpp-ethereum easier for mere mortals too.   Many people get tripped up on this.
