### PR TITLE
Added "AND GUI" conditional around OpenCL hack.

### DIFF
--- a/cmake/UseEth.cmake
+++ b/cmake/UseEth.cmake
@@ -23,7 +23,7 @@ function(eth_apply TARGET REQUIRED SUBMODULE)
 
 		# workaround for https://github.com/ethereum/alethzero/issues/69
 		# force linking to libOpenCL as early as possible
-		if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux" AND ETHASHCL)
+		if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux" AND ETHASHCL AND GUI)
 			find_package (OpenCL)
 			if (OpenCL_FOUND)
 				target_link_libraries(${TARGET} "-Wl,--no-as-needed -l${OpenCL_LIBRARIES} -Wl,--as-needed")

--- a/cmake/UseOpenCL.cmake
+++ b/cmake/UseOpenCL.cmake
@@ -3,7 +3,7 @@ function(eth_apply TARGET REQUIRED)
 	eth_show_dependency(OpenCL OpenCL)
 	if (OpenCL_FOUND)
 		target_include_directories(${TARGET} SYSTEM PUBLIC ${OpenCL_INCLUDE_DIRS})
-		if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux" AND ETHASHCL)
+		if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux" AND ETHASHCL AND GUI)
 			# workaround for https://github.com/ethereum/alethzero/issues/69
 			# force linking to libOpenCL as early as possible
 			target_link_libraries(${TARGET} "-Wl,--no-as-needed -l${OpenCL_LIBRARIES} -Wl,--as-needed")


### PR DESCRIPTION
This is an attempted fix for repeatedly reported issues with OpenCL detection on Linux (most recently openSUSE) which look like they might be caused by a hack in this file which attempts to load OpenCL early to workaround an issue at boot with AlethZero.
This "fix" won't actually solve the root issue here, but it should minimize its impact.
Also, when AlethZero and Mix are gone, we can remove all of this stuff.

Fixes https://github.com/ethereum/webthree-umbrella/issues/557.
