### PR TITLE
Upgraded from VS2013 to VS2015.

### DIFF
--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -19,6 +19,7 @@ if (DEFINED MSVC)
 
 	if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.0.0)
 		set (ETH_DEPENDENCY_INSTALL_DIR "${CMAKE_CURRENT_LIST_DIR}/../extdep/install/windows/x64")
+		message(STATUS "ETH_DEPENDENCY_INSTALL_DIR = ${ETH_DEPENDENCY_INSTALL_DIR}")
 	else()
 		get_filename_component(DEPS_DIR "${CMAKE_CURRENT_LIST_DIR}/../deps/install" ABSOLUTE)
 		set(ETH_DEPENDENCY_INSTALL_DIR
@@ -26,8 +27,10 @@ if (DEFINED MSVC)
 			"${DEPS_DIR}/win64"					# New location for deps.
 			"${DEPS_DIR}/win64/Release/share"	# LLVM shared cmake files.
 		)
+		message(STATUS "ETH_DEPENDENCY_INSTALL_DIR = ${ETH_DEPENDENCY_INSTALL_DIR}")
 	endif()
 	set (CMAKE_PREFIX_PATH ${ETH_DEPENDENCY_INSTALL_DIR} ${CMAKE_PREFIX_PATH})
+	message(STATUS "CMAKE_PREFIX_PATH = ${CMAKE_PREFIX_PATH}")
 
 	# Qt5 requires opengl
 	# TODO it windows SDK is NOT FOUND, throw ERROR

--- a/scripts/ethbinaries.sh
+++ b/scripts/ethbinaries.sh
@@ -125,7 +125,7 @@ if [[ $OSTYPE == "cygwin" ]]; then
 		echo "ETHBINARIES - ERROR: Failed to source ethwindowsenv.sh.";
 		exit 1
 	fi
-	cmake .. -G "Visual Studio 12 2013 Win64"
+	cmake .. -G "Visual Studio 14 2015 Win64"
 	if [[ $? -ne 0 ]]; then
 	echo "ETHBINARIES - ERROR: cmake configure phase in Windows failed.";
 	exit 1

--- a/scripts/ethbuild.sh
+++ b/scripts/ethbuild.sh
@@ -218,7 +218,7 @@ do
 	if [[ $OSTYPE == "cygwin" ]]; then
 		# For Windows we gotta emulate the Visual studio environment
 		source "${SCRIPT_DIR}/ethwindowsenv.sh"
-		cmake .. -G "Visual Studio 12 2013 Win64"
+		cmake .. -G "Visual Studio 14 2015 Win64"
 		if [[ $? -ne 0 ]]; then
 			echo "ETHBUILD - ERROR: cmake configure phase for repository \"$repository\" failed.";
 			exit 1

--- a/scripts/ethwindowsenv.sh
+++ b/scripts/ethwindowsenv.sh
@@ -5,7 +5,7 @@
 # Following suggestions from: http://stackoverflow.com/questions/366928/invoking-cl-exe-msvc-compiler-in-cygwin-shell
 
 # These lines will be installation-dependent.
-export VSINSTALLDIR='C:\Program Files (x86)\Microsoft Visual Studio 12.0\'
+export VSINSTALLDIR='C:\Program Files (x86)\Microsoft Visual Studio 14.0\'
 export WindowsSdkDir='C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\'
 export FrameworkDir='C:\WINDOWS\Microsoft.NET\Framework64\'
 export FrameworkDir64='C:\WINDOWS\Microsoft.NET\Framework64\'
@@ -42,4 +42,4 @@ export PATH="${c_VSINSTALLDIR}Common7/Tools:$PATH"
 export PATH="${c_VSINSTALLDIR}VC/BIN:$PATH"
 export PATH="${c_VSINSTALLDIR}Common7/IDE/:$PATH"
 
-MSBUILD_EXECUTABLE='/cygdrive/c/Program Files (x86)/MSBuild/12.0/Bin/amd64/msbuild.exe'
+MSBUILD_EXECUTABLE='/cygdrive/c/Program Files (x86)/MSBuild/14.0/Bin/amd64/msbuild.exe'


### PR DESCRIPTION
There are various hard-coded Visual Studio version references in our shell scripts:
- ethbinaries.sh (for the CMake generator choice)
- ethbuild.sh (for the CMake generator choice)
- ethwindowsenv.sh (which is an "emulation" of vcvars32.bat for Cygwin, pointing at absolute install path for VS)

And there is one further reference, inside a managed script within Jenkins for the Powershell used to make the Windows ZIP.

That is http://52.28.164.97/configfiles/show?id=org.jenkinsci.plugins.managedscripts.PowerShellConfig1444842304838, which points at the VS install location to copy the msvc*120.dll files into the ZIP.    That will need updating to 140.
