### PR TITLE
Update version to 1.2.8

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -8,7 +8,7 @@ include(EthPolicy)
 eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
-project(utils VERSION "1.2.7")
+project(utils VERSION "1.2.8")
 
 include(EthCompilerSettings)
 


### PR DESCRIPTION
Changes since 1.2.7:
- Temporarily forcing OS X binaries to Debug in ethbinaries.sh release process, as workaround for the Heisenbug.
- Moved OpenGL hack into "AND GUI" conditional, to fix openSUSE build break.
