### PR TITLE
quick fix for MacOSX 10.11.5 (El Capitan) Qt 5.6.1-1 links

### DIFF
--- a/cmake/scripts/macdeployfix.sh
+++ b/cmake/scripts/macdeployfix.sh
@@ -12,8 +12,7 @@ if [ -d ${BUILD_QML_FOLDER_PATH} ]; then
 	declare -a BROKEN_FILES;
 	k=0;
 	for j in $(find ${BUILD_QML_FOLDER_PATH} -name *.dylib); do
-		BROKEN_FILES[${k}]=$j
-		
+		BROKEN_FILES[${k}]=$j		
 		((k=k+1))
 	done
 
@@ -41,6 +40,10 @@ if [ -d ${BUILD_QML_FOLDER_PATH} ]; then
 fi
 
 # replace framework links 
+
+# July 3rd Balint Pato - libleveldb seems to be referring to libsnappy which makes verify_app fail
+install_name_tool -change /usr/local/lib/libsnappy.1.dylib @executable_path/../Frameworks/libsnappy.1.dylib  $BUILD_FOLDER_PATH/Frameworks/libleveldb.1.dylib
+
 declare -a BROKEN_FRAMEWORKS;
 k=0;
 BUILD_FRAMEWORKS_FOLDER_PATH="$BUILD_FOLDER_PATH/Frameworks"
@@ -49,10 +52,13 @@ for j in $(find ${BUILD_FRAMEWORKS_FOLDER_PATH} -name Qt*.framework); do
 	((k=k+1))
 done
 for i in "${BROKEN_FRAMEWORKS[@]}"; do
-	FRAMEWORK_FILE=$i/$(basename -s ".framework" $i)
-	otool -L $FRAMEWORK_FILE | grep -o /usr/.*Qt.*framework/\\w* | while read -a libs ; do
-	       	install_name_tool -change ${libs[0]} @loader_path/../../../`basename ${libs[0]}`.framework/`basename ${libs[0]}` $FRAMEWORK_FILE
+	# fix external references from Qt framework binaries
+	FRAMEWORK_FILE=$i/$(basename -s ".framework" $i)	
+	otool -L $FRAMEWORK_FILE | grep -o /usr/.*Qt.*framework/[^\ ]* | while read -a libs ; do
+		QT5FRAMEWORK=`basename ${libs[0]}`
+		install_name_tool -change ${libs[0]} @loader_path/../../../$QT5FRAMEWORK.framework/$QT5FRAMEWORK $FRAMEWORK_FILE
 	done
+
 	# This next loop also fixes apps included *inside* these frameworks in the same way. Currently, only QtWebEngineProcess.app inside QtWebEngineCore
 	# is affected, but trying to keep this general in case more slip through in the future.
 	# This is due to a known bug in QT5, and we have to fix up the linked libraries if we're going to have a distributable
@@ -75,25 +81,23 @@ for i in "${BROKEN_FRAMEWORKS[@]}"; do
 	# reuse this script.  It needs to work, and not a lot more than that.
 		
 	for j in $(find $i -name \*\.app); do
+		# replacing references to /usr/.../Qt* in internal executables (e.g. QtWebEngineProcess within Mix-ide) 
 		EXEC_NAME=$j/Contents/MacOS/$(basename -s .app $j)
-		otool -L $EXEC_NAME | grep -o /usr/local.*dylib | while read -a innerlibs ; do
-			install_name_tool -change ${innerlibs[0]} @executable_path/../../../../../../../../Frameworks/`basename ${innerlibs[0]}` $EXEC_NAME
+		otool -L $EXEC_NAME | grep -o /usr/local.*dylib | while read -a innerlibs ; do	
+			INNER_LIB=`basename ${innerlibs[0]}`
+			install_name_tool -change ${innerlibs[0]} @executable_path/../../../../../../../../Frameworks/$INNER_LIB $EXEC_NAME
+		done
+
+		# replacing references to /usr/.../Qt* in libraries of internal executables (e.g. QtWebEngineProcess within Mix-ide refers to QtGui) 
+		otool -L $EXEC_NAME | grep -o /usr/.*Qt.*framework/[^\ ]* | while read -a qt5libs ; do
+			QT5FRAMEWORK=`basename ${qt5libs[0]}`		
+			# note $QT5FRAMEWORK.framework/Version/5/$QT5FRAMEWORK instead of the symlink of $QT5FRAMEWORK.framework/$QT5FRAMEWORK  
+			# it's important as even though it would resolve the library - but when the library refers to another library (which we fix at the FRAMEWORK_FILE loop)
+			# it would resolve to two levels in the wrong place - as @loader_path is not using the version symlink (hence the ../../../ instead of ../)
+	       	install_name_tool -change ${qt5libs[0]} @executable_path/../../../../../../../../Frameworks/$QT5FRAMEWORK.framework/Versions/5/$QT5FRAMEWORK $EXEC_NAME
 		done
 		
 		install_name_tool -change @loader_path/../Frameworks/libdbus-1.3.dylib @executable_path/../../../../../../../../Frameworks/libdbus-1.3.dylib $EXEC_NAME
-
-		# 11th April 2016.  Bob Summerwill - Oh lovely, it's got even worse with Qt 5.6
-		# and we need more hacks again.    We've got to get to the bottom of this soon,
-		# because this is utterly unworkable.
-		install_name_tool -change @loader_path/../Frameworks/QtWebEngineCore.framework/Versions/5/QtWebEngineCore @executable_path/../../../../../../../../Frameworks/QtWebEngineCore.framework/Versions/5/QtWebEngineCore $EXEC_NAME
-		install_name_tool -change /usr/local/Cellar/qt5/5.6.0/lib/QtWebEngineCore.framework/Versions/5/QtWebEngineCore @executable_path/../../../../../../../../Frameworks/QtWebEngineCore.framework/Versions/5/QtWebEngineCore $EXEC_NAME
-		install_name_tool -change /usr/local/Cellar/qt5/5.6.0/lib/QtQuick.framework/Versions/5/QtQuick @executable_path/../../../../../../../../Frameworks/QtQuick.framework/Versions/5/QtQuick $EXEC_NAME
-		install_name_tool -change /usr/local/Cellar/qt5/5.6.0/lib/QtGui.framework/Versions/5/QtGui @executable_path/../../../../../../../../Frameworks/QtGui.framework/Versions/5/QtGui $EXEC_NAME
-		install_name_tool -change /usr/local/Cellar/qt5/5.6.0/lib/QtQml.framework/Versions/5/QtQml @executable_path/../../../../../../../../Frameworks/QtQml.framework/Versions/5/QtQml $EXEC_NAME
-		install_name_tool -change /usr/local/Cellar/qt5/5.6.0/lib/QtNetwork.framework/Versions/5/QtNetwork @executable_path/../../../../../../../../Frameworks/QtNetwork.framework/Versions/5/QtNetwork $EXEC_NAME
-		install_name_tool -change /usr/local/Cellar/qt5/5.6.0/lib/QtWebChannel.framework/Versions/5/QtWebChannel @executable_path/../../../../../../../../Frameworks/QtWebChannel.framework/Versions/5/QtWebChannel $EXEC_NAME
-		install_name_tool -change /usr/local/Cellar/qt5/5.6.0/lib/QtPositioning.framework/Versions/5/QtPositioning @executable_path/../../../../../../../../Frameworks/QtPositioning.framework/Versions/5/QtPositioning $EXEC_NAME
-		install_name_tool -change /usr/local/Cellar/qt5/5.6.0/lib/QtCore.framework/Versions/5/QtCore @executable_path/../../../../../../../../Frameworks/QtCore.framework/Versions/5/QtCore $EXEC_NAME
 
 	done
 done
@@ -107,8 +111,8 @@ for j in $(find ${BUILD_PLUGINS_FOLDER_PATH} -name *.dylib); do
 done
 for i in "${BROKEN_PLUGINS[@]}"; do
 	FRAMEWORK_FILE=$i
-	otool -L $FRAMEWORK_FILE | grep -o /usr/.*Qt.*framework/\\w* | while read -a libs ; do
-	       	install_name_tool -change ${libs[0]} @loader_path/../../Frameworks/`basename ${libs[0]}`.framework/`basename ${libs[0]}` $FRAMEWORK_FILE
+	otool -L $FRAMEWORK_FILE | grep -o /usr/.*Qt.*framework/[^\ ]* | while read -a libs ; do
+			QT5FRAMEWORK=`basename ${libs[0]}`
+	       	install_name_tool -change ${libs[0]} @loader_path/../../Frameworks/$QT5FRAMEWORK.framework/$QT5FRAMEWORK $FRAMEWORK_FILE
 	done
 done
-


### PR DESCRIPTION
Please test it for Qt 5.6.0 as well as I replaced the 5.6.0 explicit version references with more generic logic. 

On my MacOSX 10.11.5 (El Capitan) with Qt 5.6.1-1, this version of this hack seems to work fine. 

This definitely solves https://github.com/ethereum/webthree-umbrella/issues/574 and might solve https://github.com/ethereum/webthree-umbrella/issues/599 as well as I ran into similar issues during developing it. 

The final lines of the `make install` logs: 

```
-- ===========================================================================
-- Analyzing app='/Users/balopat/Library/Caches/Homebrew/webthree-umbrella/build/alethzero/alethzero/AlethZero.app'
-- bundle='/Users/balopat/Library/Caches/Homebrew/webthree-umbrella/build/alethzero/alethzero/AlethZero.app'
-- executable='/Users/balopat/Library/Caches/Homebrew/webthree-umbrella/build/alethzero/alethzero/AlethZero.app/Contents/MacOS/AlethZero'
-- valid='1'
-- executable file 1: /Users/balopat/Library/Caches/Homebrew/webthree-umbrella/build/alethzero/alethzero/AlethZero.app/Contents/MacOS/AlethZero
-- verified='1'
-- info='Verified 1 executable files in '/Users/balopat/Library/Caches/Homebrew/webthree-umbrella/build/alethzero/alethzero/AlethZero.app''
-- 
-- verified='1'
-- info=''
-- 
-- ===========================================================================
-- Analyzing app='/Users/balopat/Library/Caches/Homebrew/webthree-umbrella/build/mix/Mix-ide.app'
-- bundle='/Users/balopat/Library/Caches/Homebrew/webthree-umbrella/build/mix/Mix-ide.app'
-- executable='/Users/balopat/Library/Caches/Homebrew/webthree-umbrella/build/mix/Mix-ide.app/Contents/MacOS/Mix-ide'
-- valid='1'
-- executable file 1: /Users/balopat/Library/Caches/Homebrew/webthree-umbrella/build/mix/Mix-ide.app/Contents/Frameworks/QtWebEngineCore.framework/Versions/5/Helpers/QtWebEngineProcess.app/Contents/MacOS/QtWebEngineProcess
-- executable file 2: /Users/balopat/Library/Caches/Homebrew/webthree-umbrella/build/mix/Mix-ide.app/Contents/MacOS/Mix-ide
-- verified='1'
-- info='Verified 2 executable files in '/Users/balopat/Library/Caches/Homebrew/webthree-umbrella/build/mix/Mix-ide.app''
-- 
-- verified='1'
-- info=''
```
