### PR TITLE
Updated version number in CMake file to 1.3.0

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -8,7 +8,7 @@ include(EthPolicy)
 eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
-project(utils VERSION "1.2.9")
+project(utils VERSION "1.3.0")
 
 include(EthCompilerSettings)
 


### PR DESCRIPTION
Looks like this didn't happen for the cpp-ethereum-v1.3.0 release.
